### PR TITLE
Resolved method name conflict

### DIFF
--- a/src/SellerLabs/Injected/InjectedTrait.php
+++ b/src/SellerLabs/Injected/InjectedTrait.php
@@ -29,7 +29,7 @@ trait InjectedTrait
      *
      * @throws Exception
      */
-    protected function getDependencies()
+    protected function getDependencyMapping()
     {
         $constructor = (new ReflectionClass($this->className))
             ->getConstructor();
@@ -76,7 +76,7 @@ trait InjectedTrait
      */
     protected function mockDependencies()
     {
-        $dependencies = $this->getDependencies();
+        $dependencies = $this->getDependencyMapping();
 
         foreach ($dependencies as $interface => $memberName) {
             if (!isset($this->$memberName)) {


### PR DESCRIPTION
PHPunit 7 introduced the method getDependencies which has a different purpose than the one for this trait.
https://github.com/sebastianbergmann/phpunit/blob/master/src/Framework/TestCase.php#L962

Renamed the protected method to resolve the name clash